### PR TITLE
Get rid of non-standard const breaking strict mode

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -15,9 +15,9 @@ var qs = require('querystring');
  * Defaults
  */
 
-const DEFAULT_PORT = 27017;
-const DEFAULT_DB = 'test';
-const ADMIN_DB = 'admin';
+var DEFAULT_PORT = 27017;
+var DEFAULT_DB = 'test';
+var ADMIN_DB = 'admin';
 
 /**
  * Muri


### PR DESCRIPTION
`const` is an [ES6 feature](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/const) and shouldn't be here. Node supports it, but not in strict mode.
