### PR TITLE
Fixed Login Problem 

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -177,7 +177,7 @@ function parse (uriString) {
 
   var uri = uriString;
   var ret = {};
-  var parts;
+  var parts = [];
   var auth;
   var ipcs;
 
@@ -186,7 +186,14 @@ function parse (uriString) {
 
   // auth
   if (/@/.test(uri)) {
-    parts = uri.split(/@/);
+    //parts = uri.split(/@/);
+    
+    //pushed username:password
+    parts.push(uri.substring(0,uri.lastIndexOf('@')));
+    
+    //pushed url
+    parts.push(uri.substring(uri.lastIndexOf('@')+1,uri.length));
+
     auth = parts[0];
     uri = parts[1];
 


### PR DESCRIPTION
#6  Even if user_name and user_password contains '@' symbol this will not lead the following error.
 `{ name: 'MongoError', message: 'getaddrinfo ENOTFOUND' }`
