### PR TITLE
Fix parsing of replica set name with a leading number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -135,7 +135,7 @@ function format (val) {
   } else if ('false' == val) {
     return false;
   } else {
-    num = parseInt(val, 10);
+    num = parseInt(+val, 10);
     if (!isNaN(num)) {
       return num;
     }

--- a/test/index.js
+++ b/test/index.js
@@ -318,4 +318,11 @@ describe('muri', function(){
     assert.ok(muri.version);
     done();
   })
+
+  it('replica set name with a leading number', function(done){
+    var uri = 'mongodb://localhost:27017/test?replicaSet=1800-shard-0';
+    var val = muri(uri);
+    assert.equal('1800-shard-0', val.options.replicaSet);
+    done()
+  })
 })


### PR DESCRIPTION
Replica set name with a leading number doesn't get parsed correctly. For example, the URI:

```
mongodb://localhost:27017/test?replicaSet=1800-shard-0
```

get parsed into:

```
{ hosts: [ { host: 'localhost', port: 27017 } ],
  db: 'test',
  options: { replicaSet: 1800 } }
```

where the rest of the string after `1800` is ignored.

This PR fixes this issue.