### PR TITLE
Simpler way to fetch version

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -236,6 +236,4 @@ function parse (uriString) {
  * Version
  */
 
-module.exports.version = JSON.parse(
-  require('fs').readFileSync(__dirname + '/../package.json', 'utf8')
-).version;
+module.exports.version = require('../package.json').version;


### PR DESCRIPTION
There is no real need to use 'fs' module here. In my case it creates complications when I try to bundle AWS Lambda code using Webpack.